### PR TITLE
feat: replace "develop" non-branch name with "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Generally, a `String` to be parsed into a `Version` has to follow the following 
 
 Here are some valid examples:
 ```java
-"1.0.0-develop"
+"1.0.0-main"
 "1"
 ".2"
 "1.3-some_feature-release_candidate-0"
@@ -251,13 +251,13 @@ public class Repository {
 which then can be used like this to retrieve only the desired versions:
 
 ```java
-final List<BaseVersion> developReleases = repository.queryVersions(
+final List<BaseVersion> mainReleases = repository.queryVersions(
     new VersionTypes(
         VersionTypes.PublicationStatusType.RELEASES,
-        VersionTypes.BranchType.DEVELOP));
+        VersionTypes.BranchType.MAIN));
 
-final List<BaseVersion> developSnapshots = repository.queryVersions(
-    VersionTypes.ONLY_DEVELOP_SNAPSHOTS);
+final List<BaseVersion> mainSnapshots = repository.queryVersions(
+    VersionTypes.ONLY_MAIN_SNAPSHOTS);
 
 final List<BaseVersion> all = repository.queryVersions(VersionTypes.ALL);
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Version comparisons are carried out in the following order of precedence until o
 2. `minor` - Higher minor versions are considered greater.
 3. `incremental` - Higher incremental versions are considered greater.
 5. `snapshot status` - Release versions are considered greater than snapshot versions.
-4. `branch` - Versions with a `Branch.DEVELOP` are considered greater, others are compared lexicographically.
+4. `branch` - Versions with a `Branch.MAIN` are considered greater, others are compared lexicographically.
 6. `qualifiers` - Qualifiers are compared lexicographically (in order).  A version with fewer qualifiers is considered greater.
 7. `concrete snapshot timestamp` - If both Versions are ConcreteSnapshotVersions their `timestamp`s are compared _lexicographically_ (**not numerically!**  The result for the expected format `yyyyMMdd.HHmmss` is the same, but this is not enforced)
 8. `concrete snapshot buildnumber` - If both Versions are ConcreteSnapshotVersions the one with the higher `buildnumber` is considered greater.
@@ -128,7 +128,7 @@ Otherwise it can be configured with `VersionParser.Characteristics` with these v
 ```java
 final VersionParser parser = new VersionParser(
 
-    // do not set branches (they default to Branch.DEVELOP)
+    // do not set branches (they default to Branch.MAIN)
     VersionParser.Characteristics.IGNORE_BRANCHES,
 
     // do not set any qualifiers
@@ -142,7 +142,7 @@ Generally, a `String` to be parsed into a `Version` has to follow the following 
 `major` may be omitted if not leaving the `String` empty, defaults to zero (`0`)  
 `minor` and the leading dot (`.`) may be omitted, defaults to zero (`0`)  
 `incremental` and the leading dot (`.`) may be omitted, defaults to zero (`0`)  
-`branch` and the leading hyphon (`-`) may be omitted if no `qualifiers` are given, defaults to `Branch.DEVELOP`  
+`branch` and the leading hyphon (`-`) may be omitted if no `qualifiers` are given, defaults to `Branch.MAIN`  
 `qualifiers` and the leading hyphon (`-`) may be ommitted
 
 Here are some valid examples:

--- a/src/main/java/com/sitepark/versioning/Branch.java
+++ b/src/main/java/com/sitepark/versioning/Branch.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
  * {@link Version}s.
  * By default a {@code Version} does not explicitly define a {@code Branch}
  * (for example {@code "1.0.3"}), in which cases the "non-feature-branch"
- * {@link #DEVELOP} is used.
+ * {@link #MAIN} is used.
  *
  * <p>
  * Branches are compared alphabetically, although for "non-feature-branches"
@@ -22,12 +22,21 @@ import java.io.Serializable;
 public final class Branch implements Comparable<Branch>, Serializable {
   private static final long serialVersionUID = 7052868613896268596L;
 
+  private static final String MAIN_VALUE = "main";
   private static final String DEVELOP_VALUE = "develop";
 
   /**
    * Denotes the absense of a "feature-branch".
    */
-  public static final Branch DEVELOP = new Branch(Branch.DEVELOP_VALUE);
+  public static final Branch MAIN = new Branch(Branch.MAIN_VALUE);
+
+  /**
+   * Denotes the absense of a "feature-branch".
+   *
+   * @deprecated use {@link #MAIN} instead
+   */
+  @Deprecated(since = "3.1.0", forRemoval = true)
+  public static final Branch DEVELOP = Branch.MAIN;
 
   private final String value;
 
@@ -35,9 +44,10 @@ public final class Branch implements Comparable<Branch>, Serializable {
    * Class Constructor specifiying a String representation of the Branch.
    *
    * If an empty String is given or
-   * {@code value.equalsIgnoreCase("develop") == true} the Branch will be
+   * {@code value.equalsIgnoreCase("main") == true} (and for legacy reasons also
+   * {@code value.equalsIgnoreCase("develop") == true}) the Branch will be
    * considered a "non-feature-branch".  In this case one may want to use the
-   * {@link #DEVELOP} constant instead.
+   * {@link #MAIN} constant instead.
    *
    * @param value a String representation of a Branch
    * @throws IllegalArgumentException when the value contains spaces or
@@ -51,30 +61,39 @@ public final class Branch implements Comparable<Branch>, Serializable {
     if (value.indexOf('-') != -1) {
       throw new IllegalArgumentException("Branches cannot contain hyphens");
     }
-    this.value =
-        value.equalsIgnoreCase(Branch.DEVELOP_VALUE) || value.length() == 0
-            ? Branch.DEVELOP_VALUE
-            : value;
+    this.value = this.valueIsMain(value) ? Branch.MAIN_VALUE : value;
   }
 
   /**
    * Returns wether the Branch is considered a "non-feature-branch".
    *
-   * @return {@code true} if the Branch is equal to {@link #DEVELOP},
-   *         {@code false} otherwise
+   * @return {@code true} if the Branch is equal to
+   *         {@link #DEVELOP}/{@link #MAIN}, {@code false} otherwise
+   * @deprecated use {@link #isMain()} instead
    */
+  @Deprecated(since = "3.1.0", forRemoval = true)
   public boolean isDevelop() {
-    return this.value == Branch.DEVELOP_VALUE;
+    return this.value == Branch.MAIN_VALUE;
+  }
+
+  /**
+   * Returns wether the Branch is considered a "non-feature-branch".
+   *
+   * @return {@code true} if the Branch is equal to
+   *         {@link #DEVELOP}/{@link #MAIN}, {@code false} otherwise
+   */
+  public boolean isMain() {
+    return this.value == Branch.MAIN_VALUE;
   }
 
   /**
    * Returns wether the Branch is considered a "feature-branch" or not.
    *
-   * @return {@code true} if the Branch is not equal to {@link #DEVELOP},
-   *         {@code false} otherwise
+   * @return {@code true} if the Branch is not equal to
+   *         {@link #DEVELOP}/{@link #MAIN}, {@code false} otherwise
    */
   public boolean isFeature() {
-    return this.value != Branch.DEVELOP_VALUE;
+    return this.value != Branch.MAIN_VALUE;
   }
 
   @Override
@@ -84,14 +103,14 @@ public final class Branch implements Comparable<Branch>, Serializable {
 
   @Override
   public int compareTo(final Branch other) {
-    switch ((this.isDevelop() ? 1 : 0) + (other.isDevelop() ? 2 : 0)) {
-      case 1: // only this is develop
+    switch ((this.isMain() ? 1 : 0) + (other.isMain() ? 2 : 0)) {
+      case 1: // only this is main
         return 1;
-      case 2: // only other is develop
+      case 2: // only other is main
         return -1;
-      case 3: // both are develop
+      case 3: // both are main
         return 0;
-      default: // neither is develop
+      default: // neither is main
         return this.value.compareTo(other.value);
     }
   }
@@ -108,13 +127,20 @@ public final class Branch implements Comparable<Branch>, Serializable {
 
   /**
    * Assures that the Serializable interface does not create a new instance
-   * of {@code Branch.DEVELOP_VALUE}, which would mess up comparisons in
-   * {@code isDevelop} and {@code isFeature}.
+   * of {@link #MAIN_VALUE}/{@link #DEVELOP_VALUE}, which would mess up
+   * comparisons in {@link #isMain()}/{@link #isDevelop()} and
+   * {@link #isFeature()}.
    */
   private Object readResolve() throws ObjectStreamException {
-    if (this.value.equalsIgnoreCase(Branch.DEVELOP_VALUE) || value.length() == 0) {
-      return Branch.DEVELOP;
+    if (this.valueIsMain(this.value)) {
+      return Branch.MAIN;
     }
     return this;
+  }
+
+  private boolean valueIsMain(String value) {
+    return value.length() == 0
+        || value.equalsIgnoreCase(Branch.DEVELOP_VALUE)
+        || value.equalsIgnoreCase(Branch.MAIN_VALUE);
   }
 }

--- a/src/main/java/com/sitepark/versioning/version/Version.java
+++ b/src/main/java/com/sitepark/versioning/version/Version.java
@@ -49,7 +49,7 @@ public sealed interface Version extends Comparable<Version>
   /**
    * Returns the {@link Branch} of this Version.
    * This is never {@code null}; The absence of a feature branch is denoted
-   * by the {@link Branch#DEVELOP} instance.
+   * by the {@link Branch#MAIN} instance.
    *
    * @return the branch
    */

--- a/src/main/java/com/sitepark/versioning/version/VersionBuilder.java
+++ b/src/main/java/com/sitepark/versioning/version/VersionBuilder.java
@@ -47,7 +47,7 @@ public class VersionBuilder {
     this.major = new AtomicInteger(0);
     this.minor = new AtomicInteger(0);
     this.incremental = new AtomicInteger(0);
-    this.branch = Branch.DEVELOP;
+    this.branch = Branch.MAIN;
     this.qualifiers = Collections.synchronizedList(new LinkedList<>());
   }
 
@@ -129,7 +129,7 @@ public class VersionBuilder {
   /**
    * Specifies a {@link Branch} to set on {@link Version}s created by this
    * instance.
-   * Otherwise defaults to {@link Branch#DEVELOP}.
+   * Otherwise defaults to {@link Branch#MAIN}.
    *
    * @param branch the branch to set
    * @return this instance
@@ -142,7 +142,7 @@ public class VersionBuilder {
 
   /**
    * Returns the currently set {@link Branch}.
-   * Defaults to {@link Branch#DEVELOP}.
+   * Defaults to {@link Branch#MAIN}.
    *
    * @return the incremental version
    * @see Version#getBranch()

--- a/src/main/java/com/sitepark/versioning/version/VersionParseExecutor.java
+++ b/src/main/java/com/sitepark/versioning/version/VersionParseExecutor.java
@@ -199,7 +199,7 @@ abstract class VersionParseExecutor<R> {
   /**
    * Adds the {@link #currentItem} as {@code branch} to the
    * {@link #versionBuilder} and advances to the {@link Section#QUALIFIER}.
-   * Defaults to {@link Branch#DEVELOP} if the
+   * Defaults to {@link Branch#MAIN} if the
    * {@link VersionParser.Characteristics#IGNORE_BRANCHES} flag is set.
    *
    * @see VersionBuilder#setBranch(Branch)
@@ -207,6 +207,7 @@ abstract class VersionParseExecutor<R> {
   protected void addBranch() {
     final String branch = this.currentItem.toString();
     if (!VersionParser.Characteristics.IGNORE_BRANCHES.isSet(this.flags)
+        && !branch.equalsIgnoreCase("main")
         && !branch.equalsIgnoreCase("develop")) {
       this.versionBuilder.setBranch(new Branch(branch));
     }

--- a/src/main/java/com/sitepark/versioning/version/VersionParser.java
+++ b/src/main/java/com/sitepark/versioning/version/VersionParser.java
@@ -22,7 +22,7 @@ import java.text.ParseException;
  *   </li>
  *   <li>
  *     {@code branch} and the leading hyphon ({@code -}) may be omitted if no
- *     {@code qualifiers} are given, defaults to {@link Branch#DEVELOP}
+ *     {@code qualifiers} are given, defaults to {@link Branch#MAIN}
  *   </li>
  *   <li>
  *     {@code qualifiers} and the leading hyphon ({@code -}) may be ommitted
@@ -32,7 +32,7 @@ import java.text.ParseException;
  * <p>
  * Therefore all of these are valid examples:
  * <pre>
- *    "1.0.0-develop"
+ *    "1.0.0-main"
  *    "1"
  *    ".2"
  *    "1.3-some_feature-release_candidate-0"
@@ -66,7 +66,7 @@ import java.text.ParseException;
  * <ul>
  *   <li>
  *     {@link Characteristics#IGNORE_BRANCHES}<br>
- *     Always set the {@link Branch} to {@link Branch#DEVELOP}.  This does not
+ *     Always set the {@link Branch} to {@link Branch#MAIN}.  This does not
  *     cause {@code branch} keywords to be added to the {@code qualifiers}.
  *   </li>
  *   <li>
@@ -98,7 +98,7 @@ public class VersionParser {
    */
   public enum Characteristics {
     /**
-     * Always set the {@link Branch} to {@link Branch#DEVELOP}.
+     * Always set the {@link Branch} to {@link Branch#MAIN}.
      * This does not cause {@code branch} keywords to be added to the
      * {@code qualifiers}.
      */
@@ -161,7 +161,7 @@ public class VersionParser {
    *   </li>
    *   <li>
    *     {@code branch} and the leading hyphon ({@code -}) may be omitted if
-   *     no {@code qualifiers} are given, defaults to {@link Branch#DEVELOP}
+   *     no {@code qualifiers} are given, defaults to {@link Branch#MAIN}
    *   </li>
    *   <li>
    *     {@code qualifiers} and the leading hyphon ({@code -}) may be ommitted
@@ -171,7 +171,7 @@ public class VersionParser {
    * <p>
    * All of these are valid examples:
    * <pre>
-   *    "1.0.0-develop"
+   *    "1.0.0-main"
    *    "1"
    *    ".2"
    *    "1.3-some_feature-release_candidate-0"
@@ -216,7 +216,7 @@ public class VersionParser {
    *   </li>
    *   <li>
    *     {@code branch} and the leading hyphon ({@code -}) may be omitted if
-   *     no {@code qualifiers} are given, defaults to {@link Branch#DEVELOP}
+   *     no {@code qualifiers} are given, defaults to {@link Branch#MAIN}
    *   </li>
    *   <li>
    *     {@code qualifiers} and the leading hyphon ({@code -}) may be ommitted
@@ -230,7 +230,7 @@ public class VersionParser {
    * <p>
    * All of these are valid examples:
    * <pre>
-   *    "1.0.0-develop"
+   *    "1.0.0-main"
    *    "1"
    *    ".2"
    *    "1.3-some_feature-release_candidate-0"
@@ -280,7 +280,7 @@ public class VersionParser {
    *   </li>
    *   <li>
    *     {@code branch} and the leading hyphon ({@code -}) may be omitted if
-   *     no {@code qualifiers} are given, defaults to {@link Branch#DEVELOP}
+   *     no {@code qualifiers} are given, defaults to {@link Branch#MAIN}
    *   </li>
    *   <li>
    *     {@code qualifiers} and the leading hyphon ({@code -}) may be ommitted
@@ -294,7 +294,7 @@ public class VersionParser {
    * <p>
    * All of these are valid examples:
    * <pre>
-   *    "1.0.0-develop"
+   *    "1.0.0-main"
    *    "1"
    *    ".2"
    *    "1.3-some_feature-release_candidate-0"
@@ -338,7 +338,7 @@ public class VersionParser {
    *   </li>
    *   <li>
    *     {@code branch} and the leading hyphon ({@code -}) may be omitted if
-   *     no {@code qualifiers} are given, defaults to {@link Branch#DEVELOP}
+   *     no {@code qualifiers} are given, defaults to {@link Branch#MAIN}
    *   </li>
    *   <li>
    *     {@code qualifiers} and the leading hyphon ({@code -}) may be ommitted
@@ -353,7 +353,7 @@ public class VersionParser {
    * <p>
    * All of these are valid examples:
    * <pre>
-   *    "1.0.0-develop"
+   *    "1.0.0-main"
    *    "1"
    *    ".2"
    *    "1.3-some_feature-release_candidate-0"
@@ -404,7 +404,7 @@ public class VersionParser {
    *   </li>
    *   <li>
    *     {@code branch} and the leading hyphon ({@code -}) may be omitted if
-   *     no {@code qualifiers} are given, defaults to {@link Branch#DEVELOP}
+   *     no {@code qualifiers} are given, defaults to {@link Branch#MAIN}
    *   </li>
    *   <li>
    *     {@code qualifiers} and the leading hyphon ({@code -}) may be ommitted
@@ -419,7 +419,7 @@ public class VersionParser {
    * <p>
    * All of these are valid examples:
    * <pre>
-   *    "1.0.0-develop"
+   *    "1.0.0-main"
    *    "1"
    *    ".2"
    *    "1.3-some_feature-release_candidate-0"

--- a/src/main/java/com/sitepark/versioning/version/VersionTypes.java
+++ b/src/main/java/com/sitepark/versioning/version/VersionTypes.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * <ul>
  *   <li>{@link PublicationStatusType#RELEASES}</li>
  *   <li>{@link PublicationStatusType#SNAPSHOTS}</li>
- *   <li>{@link BranchType#DEVELOP}</li>
+ *   <li>{@link BranchType#MAIN}</li>
  *   <li>{@link BranchType#FEATURES}</li>
  * </ul>
  * A VersionTypes instance may include any number of these.
@@ -107,12 +107,12 @@ public final class VersionTypes {
    * {@link Version}s by their {@link Branch}.
    * A {@code Version} will always fall into exactly one of these categories:
    * <ul>
-   *   <li>{@link BranchType#DEVELOP}</li>
+   *   <li>{@link BranchType#MAIN}</li>
    *   <li>{@link BranchType#FEATURES}</li>
    * </ul>
    *
    * @see Version#getBranch
-   * @see Branch#isDevelop()
+   * @see Branch#isMain()
    * @see Branch#isFeature()
    */
   public static final class BranchType extends Type {
@@ -120,9 +120,18 @@ public final class VersionTypes {
      * Represents {@link Version}s with a "non-feature-branch" in
      * {@link VersionTypes}.
      *
-     * @see Branch#isDevelop()
+     * @see Branch#isMain()
      */
-    public static final BranchType DEVELOP = new BranchType("develop", 0b0000_0100);
+    public static final BranchType MAIN = new BranchType("main", 0b0000_0100);
+
+    /**
+     * Represents {@link Version}s with a "non-feature-branch" in
+     * {@link VersionTypes}.
+     *
+     * @deprecated use {@link #MAIN} instead
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    public static final BranchType DEVELOP = BranchType.MAIN;
 
     /**
      * Represents {@link Version}s with a "feature-branch" in
@@ -142,14 +151,14 @@ public final class VersionTypes {
     /**
      * Returns an array of all instances, which are:
      * <ul>
-     *   <li>{@link BranchType#DEVELOP}</li>
+     *   <li>{@link BranchType#MAIN}</li>
      *   <li>{@link BranchType#FEATURES}</li>
      * </ul>
      *
      * @return all {@code BranchType} instances
      */
     public static BranchType[] values() {
-      return new BranchType[] {BranchType.DEVELOP, BranchType.FEATURES};
+      return new BranchType[] {BranchType.MAIN, BranchType.FEATURES};
     }
   }
 
@@ -159,28 +168,58 @@ public final class VersionTypes {
   public static final VersionTypes NONE = new VersionTypes((byte) 0b0000_0000);
 
   /**
-   * Instance that includes exactly {@link BranchType#DEVELOP}
+   * Instance that includes exactly {@link BranchType#MAIN}
    * and {@link PublicationStatusType#RELEASES}.
    */
-  public static final VersionTypes ONLY_DEVELOP_RELEASES =
-      new VersionTypes(BranchType.DEVELOP, PublicationStatusType.RELEASES);
+  public static final VersionTypes ONLY_MAIN_RELEASES =
+      new VersionTypes(BranchType.MAIN, PublicationStatusType.RELEASES);
 
   /**
-   * Instance that includes exactly {@link BranchType#DEVELOP}
+   * Instance that includes exactly {@link BranchType#MAIN}
+   * and {@link PublicationStatusType#RELEASES}.
+   *
+   * @deprecated use {@link #ONLY_MAIN_RELEASES} instead
+   */
+  @Deprecated(since = "3.1.0", forRemoval = true)
+  public static final VersionTypes ONLY_DEVELOP_RELEASES = VersionTypes.ONLY_MAIN_RELEASES;
+
+  /**
+   * Instance that includes exactly {@link BranchType#MAIN}
    * and {@link PublicationStatusType#SNAPSHOTS}.
    */
-  public static final VersionTypes ONLY_DEVELOP_SNAPSHOTS =
-      new VersionTypes(BranchType.DEVELOP, PublicationStatusType.SNAPSHOTS);
+  public static final VersionTypes ONLY_MAIN_SNAPSHOTS =
+      new VersionTypes(BranchType.MAIN, PublicationStatusType.SNAPSHOTS);
 
   /**
-   * Instance that includes exactly {@link BranchType#DEVELOP},
+   * Instance that includes exactly {@link BranchType#MAIN}
+   * and {@link PublicationStatusType#SNAPSHOTS}.
+   *
+   * @deprecated use {@link #ONLY_MAIN_SNAPSHOTS} instead
+   */
+  @Deprecated(since = "3.1.0", forRemoval = true)
+  public static final VersionTypes ONLY_DEVELOP_SNAPSHOTS = VersionTypes.ONLY_MAIN_SNAPSHOTS;
+
+  /**
+   * Instance that includes exactly {@link BranchType#MAIN},
    * {@link PublicationStatusType#RELEASES} and
    * {@link PublicationStatusType#SNAPSHOTS}.
    * This excludes only {@link BranchType#FEATURES}.
    */
-  public static final VersionTypes DEVELOP_RELEASES_AND_SNAPSHOTS =
+  public static final VersionTypes MAIN_RELEASES_AND_SNAPSHOTS =
       new VersionTypes(
-          BranchType.DEVELOP, PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS);
+          BranchType.MAIN, PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS);
+
+  /**
+   * Instance that includes exactly {@link BranchType#MAIN},
+   * {@link PublicationStatusType#RELEASES} and
+   * {@link PublicationStatusType#SNAPSHOTS}.
+   * This excludes only {@link BranchType#FEATURES}.
+   *
+   * @deprecated use {@link #MAIN_RELEASES_AND_SNAPSHOTS} instead
+   */
+  @Deprecated(since = "3.1.0", forRemoval = true)
+  public static final VersionTypes DEVELOP_RELEASES_AND_SNAPSHOTS =
+      VersionTypes.MAIN_RELEASES_AND_SNAPSHOTS;
 
   /**
    * Instance that includes all {@link Type}s.
@@ -283,11 +322,11 @@ public final class VersionTypes {
   public Set<BranchType> getBranchTypes() {
     switch (this.value & 0b0000_1100) {
       case 0b0000_0100:
-        return Set.of(BranchType.DEVELOP);
+        return Set.of(BranchType.MAIN);
       case 0b0000_1000:
         return Set.of(BranchType.FEATURES);
       case 0b0000_1100:
-        return Set.of(BranchType.DEVELOP, BranchType.FEATURES);
+        return Set.of(BranchType.MAIN, BranchType.FEATURES);
       default:
         return Set.of();
     }
@@ -311,14 +350,14 @@ public final class VersionTypes {
       case 0b0000_0011:
         return Set.of(PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS);
       case 0b0000_0100:
-        return Set.of(BranchType.DEVELOP);
+        return Set.of(BranchType.MAIN);
       case 0b0000_0101:
-        return Set.of(PublicationStatusType.RELEASES, BranchType.DEVELOP);
+        return Set.of(PublicationStatusType.RELEASES, BranchType.MAIN);
       case 0b0000_0110:
-        return Set.of(PublicationStatusType.SNAPSHOTS, BranchType.DEVELOP);
+        return Set.of(PublicationStatusType.SNAPSHOTS, BranchType.MAIN);
       case 0b0000_0111:
         return Set.of(
-            PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS, BranchType.DEVELOP);
+            PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS, BranchType.MAIN);
       case 0b0000_1000:
         return Set.of(BranchType.FEATURES);
       case 0b0000_1001:
@@ -329,16 +368,16 @@ public final class VersionTypes {
         return Set.of(
             PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS, BranchType.FEATURES);
       case 0b0000_1100:
-        return Set.of(BranchType.DEVELOP, BranchType.FEATURES);
+        return Set.of(BranchType.MAIN, BranchType.FEATURES);
       case 0b0000_1101:
-        return Set.of(PublicationStatusType.RELEASES, BranchType.DEVELOP, BranchType.FEATURES);
+        return Set.of(PublicationStatusType.RELEASES, BranchType.MAIN, BranchType.FEATURES);
       case 0b0000_1110:
-        return Set.of(PublicationStatusType.SNAPSHOTS, BranchType.DEVELOP, BranchType.FEATURES);
+        return Set.of(PublicationStatusType.SNAPSHOTS, BranchType.MAIN, BranchType.FEATURES);
       case 0b0000_1111:
         return Set.of(
             PublicationStatusType.RELEASES,
             PublicationStatusType.SNAPSHOTS,
-            BranchType.DEVELOP,
+            BranchType.MAIN,
             BranchType.FEATURES);
       default:
         return Set.of();

--- a/src/main/java/com/sitepark/versioning/version/specification/VersionsSpecificationParser.java
+++ b/src/main/java/com/sitepark/versioning/version/specification/VersionsSpecificationParser.java
@@ -31,8 +31,8 @@ import java.text.ParseException;
  *     {@link Version}s are sensitive to {@link Branch}es.  {@code Version}s in
  *     a {@link VersionRangeElement} may define a {@code Branch} (all the same),
  *     which then implies that only {@code Version}s with this {@code Branch}
- *     are included.  The absence of a {@code Branch} and {@code "develop"} are
- *     considered equal.
+ *     are included.  The absence of a {@code Branch} and {@code "main"} (for
+ *     legacy reasons also {@code "develop"}) are considered equal.
  *   </li>
  * </ul>
  *

--- a/src/test/java/com/sitepark/versioning/BranchTest.java
+++ b/src/test/java/com/sitepark/versioning/BranchTest.java
@@ -1,52 +1,56 @@
 package com.sitepark.versioning;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BranchTest {
 
   @Test
-  public void testDevelopIsDevelop() {
-    Assertions.assertTrue(new Branch("develop").isDevelop());
-    Assertions.assertTrue(new Branch("DEVELOP").isDevelop());
-    Assertions.assertTrue(new Branch("").isDevelop());
-    Assertions.assertTrue(Branch.DEVELOP.isDevelop());
+  public void testIsMain() {
+    final List<Branch> branches =
+        List.of(
+            new Branch("develop"),
+            new Branch("DEVELOP"),
+            Branch.DEVELOP,
+            new Branch("main"),
+            new Branch("MAIN"),
+            Branch.MAIN,
+            new Branch(""));
+    for (final Branch branch : branches) {
+      Assertions.assertTrue(branch.isDevelop());
+      Assertions.assertTrue(branch.isMain());
+      Assertions.assertFalse(branch.isFeature());
+    }
   }
 
   @Test
-  public void testFeatureIsFeature() {
-    Assertions.assertTrue(new Branch("my_feature").isFeature());
-    Assertions.assertTrue(new Branch("DEVE.LOP").isFeature());
-    Assertions.assertTrue(new Branch("_").isFeature());
+  public void testIsFeature() {
+    final List<Branch> branches =
+        List.of(new Branch("my_feature"), new Branch("DEVE.LOP"), new Branch("_"));
+    for (final Branch branch : branches) {
+      Assertions.assertTrue(branch.isFeature());
+      Assertions.assertFalse(branch.isDevelop());
+      Assertions.assertFalse(branch.isMain());
+    }
   }
 
   @Test
-  public void testDevelopIsNotFeature() {
-    Assertions.assertFalse(new Branch("develop").isFeature());
-    Assertions.assertFalse(new Branch("DEVELOP").isFeature());
-    Assertions.assertFalse(new Branch("").isFeature());
-    Assertions.assertFalse(Branch.DEVELOP.isFeature());
+  public void testToString() {
+    Assertions.assertEquals("main", new Branch("develop").toString());
+    Assertions.assertEquals("main", new Branch("DEVELOP").toString());
+    Assertions.assertEquals("main", Branch.DEVELOP.toString());
+    Assertions.assertEquals("main", new Branch("main").toString());
+    Assertions.assertEquals("main", new Branch("MAIN").toString());
+    Assertions.assertEquals("main", Branch.MAIN.toString());
+    Assertions.assertEquals("main", new Branch("").toString());
+    Assertions.assertEquals("my_feature", new Branch("my_feature").toString());
   }
 
   @Test
-  public void testFeatureIsNotDevelop() {
-    Assertions.assertFalse(new Branch("my_feature").isDevelop());
-    Assertions.assertFalse(new Branch("DEVE.LOP").isDevelop());
-    Assertions.assertFalse(new Branch("_").isDevelop());
-  }
-
-  @Test
-  public void testDevelopToString() {
-    Assertions.assertEquals("develop", new Branch("develop").toString());
-    Assertions.assertEquals("develop", new Branch("DEVELOP").toString());
-    Assertions.assertEquals("develop", new Branch("").toString());
-    Assertions.assertEquals("develop", Branch.DEVELOP.toString());
-  }
-
-  @Test
-  public void testDevelopIsGreaterThanFeature() {
-    Assertions.assertTrue(Branch.DEVELOP.compareTo(new Branch("z_feature")) > 0);
-    Assertions.assertTrue(Branch.DEVELOP.compareTo(new Branch("a_feature")) > 0);
+  public void testMainIsGreaterThanFeature() {
+    Assertions.assertTrue(Branch.MAIN.compareTo(new Branch("z_feature")) > 0);
+    Assertions.assertTrue(Branch.MAIN.compareTo(new Branch("a_feature")) > 0);
   }
 
   @Test

--- a/src/test/java/com/sitepark/versioning/version/VersionParserTest.java
+++ b/src/test/java/com/sitepark/versioning/version/VersionParserTest.java
@@ -29,7 +29,7 @@ public class VersionParserTest {
     Assertions.assertEquals(1, version.getMajor());
     Assertions.assertEquals(2, version.getMinor());
     Assertions.assertEquals(3, version.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, version.getBranch());
+    Assertions.assertEquals(Branch.MAIN, version.getBranch());
     Assertions.assertEquals(0, version.getQualifiers().size());
   }
 
@@ -40,7 +40,19 @@ public class VersionParserTest {
     Assertions.assertEquals(1, version.getMajor());
     Assertions.assertEquals(2, version.getMinor());
     Assertions.assertEquals(3, version.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, version.getBranch());
+    Assertions.assertEquals(Branch.MAIN, version.getBranch());
+    Assertions.assertEquals("qualifierA", version.getQualifiers().get(0));
+    Assertions.assertEquals("qualifierB", version.getQualifiers().get(1));
+  }
+
+  @Test
+  public void testFullMainRelease() throws ParseException {
+    final ReleaseVersion version =
+        VersionParserTest.PARSER.parseRelease("1.2.3-main-qualifierA-qualifierB");
+    Assertions.assertEquals(1, version.getMajor());
+    Assertions.assertEquals(2, version.getMinor());
+    Assertions.assertEquals(3, version.getIncremental());
+    Assertions.assertEquals(Branch.MAIN, version.getBranch());
     Assertions.assertEquals("qualifierA", version.getQualifiers().get(0));
     Assertions.assertEquals("qualifierB", version.getQualifiers().get(1));
   }
@@ -281,7 +293,7 @@ public class VersionParserTest {
     Assertions.assertEquals(1, snapshot.getMajor());
     Assertions.assertEquals(2, snapshot.getMinor());
     Assertions.assertEquals(3, snapshot.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, snapshot.getBranch());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
     Assertions.assertEquals(0, snapshot.getQualifiers().size());
     Assertions.assertEquals("20210101.131313", snapshot.getTimestamp());
     Assertions.assertEquals(123, snapshot.getBuildnumber());
@@ -299,7 +311,26 @@ public class VersionParserTest {
     Assertions.assertEquals(1, snapshot.getMajor());
     Assertions.assertEquals(2, snapshot.getMinor());
     Assertions.assertEquals(3, snapshot.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, snapshot.getBranch());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
+    Assertions.assertEquals("qualifierA", snapshot.getQualifiers().get(0));
+    Assertions.assertEquals("qualifierB", snapshot.getQualifiers().get(1));
+    Assertions.assertEquals("20210101.131313", snapshot.getTimestamp());
+    Assertions.assertEquals(123, snapshot.getBuildnumber());
+  }
+
+  @Test
+  public void testConcreteFullMainSnapshot() throws ParseException {
+    final ConcreteVersion version =
+        VersionParserTest.PARSER.parseConcreteVersion(
+            "1.2.3-main-qualifierA-qualifierB-20210101.131313-123");
+    if (!(version instanceof final ConcreteSnapshotVersion snapshot)) {
+      Assertions.fail("expected concrete-snapshot-version");
+      return;
+    }
+    Assertions.assertEquals(1, snapshot.getMajor());
+    Assertions.assertEquals(2, snapshot.getMinor());
+    Assertions.assertEquals(3, snapshot.getIncremental());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
     Assertions.assertEquals("qualifierA", snapshot.getQualifiers().get(0));
     Assertions.assertEquals("qualifierB", snapshot.getQualifiers().get(1));
     Assertions.assertEquals("20210101.131313", snapshot.getTimestamp());
@@ -450,7 +481,7 @@ public class VersionParserTest {
     Assertions.assertEquals(0, snapshot.getMajor());
     Assertions.assertEquals(0, snapshot.getMinor());
     Assertions.assertEquals(0, snapshot.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, snapshot.getBranch());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
     Assertions.assertEquals(0, snapshot.getQualifiers().size());
     Assertions.assertEquals("20210101.131313", snapshot.getTimestamp());
     Assertions.assertEquals(123, snapshot.getBuildnumber());
@@ -640,7 +671,7 @@ public class VersionParserTest {
     Assertions.assertEquals(1, snapshot.getMajor());
     Assertions.assertEquals(2, snapshot.getMinor());
     Assertions.assertEquals(3, snapshot.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, snapshot.getBranch());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
     Assertions.assertEquals(0, snapshot.getQualifiers().size());
   }
 
@@ -655,7 +686,23 @@ public class VersionParserTest {
     Assertions.assertEquals(1, snapshot.getMajor());
     Assertions.assertEquals(2, snapshot.getMinor());
     Assertions.assertEquals(3, snapshot.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, snapshot.getBranch());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
+    Assertions.assertEquals("qualifierA", snapshot.getQualifiers().get(0));
+    Assertions.assertEquals("qualifierB", snapshot.getQualifiers().get(1));
+  }
+
+  @Test
+  public void testFullMainSnapshot() throws ParseException {
+    final BaseVersion version =
+        VersionParserTest.PARSER.parseBaseVersion("1.2.3-main-qualifierA-qualifierB-SNAPSHOT");
+    if (!(version instanceof final SnapshotVersion snapshot)) {
+      Assertions.fail("expected snapshot-version");
+      return;
+    }
+    Assertions.assertEquals(1, snapshot.getMajor());
+    Assertions.assertEquals(2, snapshot.getMinor());
+    Assertions.assertEquals(3, snapshot.getIncremental());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
     Assertions.assertEquals("qualifierA", snapshot.getQualifiers().get(0));
     Assertions.assertEquals("qualifierB", snapshot.getQualifiers().get(1));
   }
@@ -782,7 +829,7 @@ public class VersionParserTest {
     Assertions.assertEquals(0, snapshot.getMajor());
     Assertions.assertEquals(0, snapshot.getMinor());
     Assertions.assertEquals(0, snapshot.getIncremental());
-    Assertions.assertEquals(Branch.DEVELOP, snapshot.getBranch());
+    Assertions.assertEquals(Branch.MAIN, snapshot.getBranch());
     Assertions.assertEquals(0, snapshot.getQualifiers().size());
   }
 

--- a/src/test/java/com/sitepark/versioning/version/VersionTest.java
+++ b/src/test/java/com/sitepark/versioning/version/VersionTest.java
@@ -77,6 +77,16 @@ public class VersionTest {
   }
 
   @Test
+  public void testMainBranchCompareTo() throws ParseException {
+    final Version smaller = VersionTest.PARSER.parseRelease("1.1.1-Zfeature");
+    final Version bigger = VersionTest.PARSER.parseRelease("1.1.1-main");
+    Assertions.assertTrue(smaller.compareTo(bigger) < 0);
+    Assertions.assertTrue(bigger.compareTo(smaller) > 0);
+    Assertions.assertTrue(smaller.compareTo(smaller) == 0);
+    Assertions.assertTrue(bigger.compareTo(bigger) == 0);
+  }
+
+  @Test
   public void testSnapshotCompareTo() throws ParseException {
     final Version smaller = VersionTest.PARSER.parseBaseVersion("1.1.1-branch-SNAPSHOT");
     final Version bigger = VersionTest.PARSER.parseBaseVersion("1.1.1-branch");

--- a/src/test/java/com/sitepark/versioning/version/VersionTypesTest.java
+++ b/src/test/java/com/sitepark/versioning/version/VersionTypesTest.java
@@ -22,9 +22,25 @@ public class VersionTypesTest {
         VersionTypes.ONLY_DEVELOP_RELEASES.getBranchTypes(),
         "ONLY_DEVELOP_RELEASES should only contain BranchType.DEVELOP");
     Assertions.assertEquals(
+        Set.of(BranchType.MAIN),
+        VersionTypes.ONLY_DEVELOP_RELEASES.getBranchTypes(),
+        "ONLY_DEVELOP_RELEASES should only contain BranchType.MAIN");
+    Assertions.assertEquals(
         Set.of(PublicationStatusType.RELEASES),
         VersionTypes.ONLY_DEVELOP_RELEASES.getPublicationStatusTypes(),
         "ONLY_DEVELOP_RELEASES should only contain PublicationStatusType.RELEASES");
+  }
+
+  @Test
+  public void testOnlyMainReleases() {
+    Assertions.assertEquals(
+        Set.of(BranchType.MAIN),
+        VersionTypes.ONLY_MAIN_RELEASES.getBranchTypes(),
+        "ONLY_MAIN_RELEASES should only contain BranchType.MAIN");
+    Assertions.assertEquals(
+        Set.of(PublicationStatusType.RELEASES),
+        VersionTypes.ONLY_MAIN_RELEASES.getPublicationStatusTypes(),
+        "ONLY_MAIN_RELEASES should only contain PublicationStatusType.RELEASES");
   }
 
   @Test
@@ -34,9 +50,25 @@ public class VersionTypesTest {
         VersionTypes.ONLY_DEVELOP_SNAPSHOTS.getBranchTypes(),
         "ONLY_DEVELOP_SNAPSHOTS should only contain BranchType.DEVELOP");
     Assertions.assertEquals(
+        Set.of(BranchType.MAIN),
+        VersionTypes.ONLY_DEVELOP_SNAPSHOTS.getBranchTypes(),
+        "ONLY_DEVELOP_SNAPSHOTS should only contain BranchType.MAIN");
+    Assertions.assertEquals(
         Set.of(PublicationStatusType.SNAPSHOTS),
         VersionTypes.ONLY_DEVELOP_SNAPSHOTS.getPublicationStatusTypes(),
         "ONLY_DEVELOP_SNAPSHOTS should only contain PublicationStatusType.SNAPSHOTS");
+  }
+
+  @Test
+  public void testOnlyMainSnapshots() {
+    Assertions.assertEquals(
+        Set.of(BranchType.MAIN),
+        VersionTypes.ONLY_MAIN_SNAPSHOTS.getBranchTypes(),
+        "ONLY_MAIN_SNAPSHOTS should only contain BranchType.MAIN");
+    Assertions.assertEquals(
+        Set.of(PublicationStatusType.SNAPSHOTS),
+        VersionTypes.ONLY_MAIN_SNAPSHOTS.getPublicationStatusTypes(),
+        "ONLY_MAIN_SNAPSHOTS should only contain PublicationStatusType.SNAPSHOTS");
   }
 
   @Test
@@ -46,10 +78,28 @@ public class VersionTypesTest {
         VersionTypes.DEVELOP_RELEASES_AND_SNAPSHOTS.getBranchTypes(),
         "DEVELOP_RELEASES_AND_SNAPSHOTS should only contain BranchType.DEVELOP");
     Assertions.assertEquals(
+        Set.of(BranchType.MAIN),
+        VersionTypes.DEVELOP_RELEASES_AND_SNAPSHOTS.getBranchTypes(),
+        "DEVELOP_RELEASES_AND_SNAPSHOTS should only contain BranchType.MAIN");
+    Assertions.assertEquals(
         // order matters!
         Set.of(PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS),
         VersionTypes.DEVELOP_RELEASES_AND_SNAPSHOTS.getPublicationStatusTypes(),
         "DEVELOP_RELEASES_AND_SNAPSHOTS should contain PublicationStatusType.SNAPSHOTS and"
+            + " RELEASES");
+  }
+
+  @Test
+  public void testMainReleasesAndSnapshots() {
+    Assertions.assertEquals(
+        Set.of(BranchType.MAIN),
+        VersionTypes.MAIN_RELEASES_AND_SNAPSHOTS.getBranchTypes(),
+        "MAIN_RELEASES_AND_SNAPSHOTS should only contain BranchType.MAIN");
+    Assertions.assertEquals(
+        // order matters!
+        Set.of(PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS),
+        VersionTypes.MAIN_RELEASES_AND_SNAPSHOTS.getPublicationStatusTypes(),
+        "MAIN_RELEASES_AND_SNAPSHOTS should contain PublicationStatusType.SNAPSHOTS and"
             + " RELEASES");
   }
 
@@ -60,6 +110,11 @@ public class VersionTypesTest {
         Set.of(BranchType.DEVELOP, BranchType.FEATURES),
         VersionTypes.ALL.getBranchTypes(),
         "ALL should contain BranchTypes.DEVELOP and FEATURE");
+    Assertions.assertEquals(
+        // order matters!
+        Set.of(BranchType.MAIN, BranchType.FEATURES),
+        VersionTypes.ALL.getBranchTypes(),
+        "ALL should contain BranchTypes.MAIN and FEATURE");
     Assertions.assertEquals(
         // order matters!
         Set.of(PublicationStatusType.RELEASES, PublicationStatusType.SNAPSHOTS),


### PR DESCRIPTION
the branch-name "develop" for non-feature-branches origins from an old git workflow that we no longer use. the appropriate value to change it to would be "main" as that is the git-branch that has replaced it.

"develop" variants of constants and methods have been kept but deprecated with the intention to remove them in a later major version.

this tries to keep compatibility as much as possible - the only exception is the return value of `toString()` methods.
